### PR TITLE
fix the zed installer directory function

### DIFF
--- a/src/Spryker/Zed/SetupFrontend/SetupFrontendConfig.php
+++ b/src/Spryker/Zed/SetupFrontend/SetupFrontendConfig.php
@@ -41,11 +41,13 @@ class SetupFrontendConfig extends AbstractBundleConfig
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getYvesInstallerDirectoryPattern()
     {
-        return $this->get(KernelConstants::SPRYKER_ROOT) . '/*/assets/Yves';
+        return [
+            APPLICATION_ROOT_DIR . 'vendor/spryker/*/assets/Yves'
+        ];
     }
 
     /**
@@ -75,11 +77,14 @@ class SetupFrontendConfig extends AbstractBundleConfig
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getZedInstallerDirectoryPattern()
     {
-        return $this->get(KernelConstants::SPRYKER_ROOT) . '/*/assets/Zed';
+        return [
+            APPLICATION_ROOT_DIR . '/vendor/spryker/*/assets/Zed',
+            APPLICATION_ROOT_DIR . '/src/Pyz/Zed/*/assets/Zed'
+        ];
     }
 
     /**


### PR DESCRIPTION
In order to install zed modules dependencies in project level and vendor folder, the getZedInstallerDirectoryPattern should include the path to /src/Pyz/Zed.
Symfony Finder allows directory path or an array of directories as input. 